### PR TITLE
Fix typo, start time bug, and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The application uses various performance optimizations to ensure a smooth user e
 ### Prerequisites
 - Node.js (v16 or higher)
 - Angular CLI (v17 or higher)
+  - Install globally with `npm install -g @angular/cli`
 
 ### Installation
 1. Clone the repository

--- a/vocab-quiz/src/app/home.component.ts
+++ b/vocab-quiz/src/app/home.component.ts
@@ -319,8 +319,8 @@ export class HomeComponent implements OnInit {
   }
   
   openSettings() {
-    // This would normally open a dialog, but for this implementation
-    // we'll just move to the next step
+    // Advance to the image step; API settings are configured
+    // through the header dialog in this app
     this.currentStep = 'image';
   }
   

--- a/vocab-quiz/src/app/openai.service.ts
+++ b/vocab-quiz/src/app/openai.service.ts
@@ -38,7 +38,7 @@ When multiple definitions are supplied (synonyms or other words for the same mea
 e.g. "cake, pastry, dessert" should be split into three entries: "cake", "pastry", "dessert". "spring -> brook or jump into action" should be split into two entries: "brook" and "jump into action".
 Only extract these from the image, do not supplement with any additional information! If it is not in the image, do not include it in the response!
 
-Exammple:
+Example:
 | word | definition |
 |------|------------|
 | cake | pastry, dessert |

--- a/vocab-quiz/src/app/quiz.service.spec.ts
+++ b/vocab-quiz/src/app/quiz.service.spec.ts
@@ -38,6 +38,17 @@ describe('QuizService', () => {
     expect(service).toBeTruthy();
   });
 
+  it('should set startTime when generating a quiz', () => {
+    const quiz = service.generateQuiz({
+      quizType: 'word',
+      questionCount: 1,
+      randomizeOrder: false
+    });
+
+    expect(quiz.startTime).toBeDefined();
+    expect(quiz.startTime instanceof Date).toBeTrue();
+  });
+
   describe('Multiple word definition matching', () => {
     let defQuestion: QuizQuestion;
 

--- a/vocab-quiz/src/app/quiz.service.ts
+++ b/vocab-quiz/src/app/quiz.service.ts
@@ -56,6 +56,7 @@ export class QuizService {
       title: `Vocabulary Quiz (${settings.quizType})`,
       settings,
       questions,
+      startTime: new Date(),
       currentQuestionIndex: 0,
       isComplete: false
     };


### PR DESCRIPTION
## Summary
- fix "Example" typo in OpenAI service
- record quiz start time when generating a quiz
- clarify openSettings comment
- test that generateQuiz sets startTime
- document Angular CLI installation

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882a6932598832a804cf229a9517a42